### PR TITLE
Using git branches for versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Withal, it is not necessary to work within release channels, and the user might 
 ```yaml
 - uses: werf/actions/converge@v1.1
   with:
-    version: v1.1.16
+    version: v1.1.23
 ```
 
 ### kubeconfig setup (*optional*)

--- a/README.md
+++ b/README.md
@@ -25,21 +25,20 @@ Each action combines all the necessary steps in itself and logic may be divided 
 ### werf binary setup
 
 By default, all actions setup actual werf version for [1.1 alpha channel](https://werf.io/releases.html) (more details about channels, werf release cycle and compatibility promise [here](https://github.com/werf/werf#backward-compatibility-promise)). 
-Using `group` and `channel` inputs the user can switch the release channel.
+Using the `channel` input the user can switch the release channel.
 
 > This is recommended approach to be up-to-date and to use actual werf version without changing configurations
   
 ```yaml
-- uses: werf/actions/converge@master
+- uses: werf/actions/converge@v1.1
   with:
-    group: 1.1
     channel: alpha
 ```
   
 Withal, it is not necessary to work within release channels, and the user might specify certain werf version with `version` input.
 
 ```yaml
-- uses: werf/actions/converge@master
+- uses: werf/actions/converge@v1.1
   with:
     version: v1.1.16
 ```
@@ -53,7 +52,7 @@ The _kubeconfig_ may be used for deployment, cleanup, distributed locks and cach
 * Pass secret with `kube-config-base64-data` input:
  
   ```yaml
-  - uses: werf/actions/build-and-publish@master
+  - uses: werf/actions/build-and-publish@v1.1
     with:
       kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
   ```
@@ -71,7 +70,7 @@ By default, action will use the token provided to your workflow.
 Any werf option can be defined with environment variables:
 
 ```yaml
-- uses: werf/actions/build-and-publish@master
+- uses: werf/actions/build-and-publish@v1.1
   env:
     WERF_LOG_VERBOSE: "on"
     WERF_TAG_CUSTOM_TAG1: tag1
@@ -94,7 +93,7 @@ converge:
         fetch-depth: 0
 
     - name: Converge
-      uses: werf/actions/converge@master
+      uses: werf/actions/converge@v1.1
       with:
         env: production
         kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
@@ -114,7 +113,7 @@ build-and-publish:
         fetch-depth: 0
 
     - name: Build and Publish
-      uses: werf/actions/build-and-publish@master
+      uses: werf/actions/build-and-publish@v1.1
       with:
         kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
 
@@ -130,7 +129,7 @@ deploy:
         fetch-depth: 0
 
     - name: Deploy
-      uses: werf/actions/deploy@master
+      uses: werf/actions/deploy@v1.1
       with:
         env: production
         kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
@@ -148,7 +147,7 @@ dismiss:
       uses: actions/checkout@v2
 
     - name: Dismiss
-      uses: werf/actions/dismiss@master
+      uses: werf/actions/dismiss@v1.1
       with:
         kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
         env: production
@@ -168,7 +167,7 @@ run:
         fetch-depth: 0
 
     - name: Run
-      uses: werf/actions/run@master
+      uses: werf/actions/run@v1.1
       with:
         image: backend
         args: rails server
@@ -192,7 +191,7 @@ cleanup:
       run: git fetch --prune --unshallow
 
     - name: Cleanup
-      uses: werf/actions/cleanup@master
+      uses: werf/actions/cleanup@v1.1
       with:
         kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
 ```
@@ -206,10 +205,10 @@ werf:
   steps:
   
     - name: Checkout code  
-      uses: actions/checkout@master
+      uses: actions/checkout@v1.1
 
     - name: Install werf CLI  
-      uses: werf/actions/install@master
+      uses: werf/actions/install@v1.1
     
     # for deploy and distributed locks
     - name: Create kube config

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,6 @@ branding:
   color: blue
   icon: anchor
 inputs:
-  group:
-    description: 'The MAJOR.MINOR version'
-    default: '1.1'
-    required: false
   channel:
     description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
     default: 'alpha'

--- a/build-and-publish/README.md
+++ b/build-and-publish/README.md
@@ -25,7 +25,7 @@ Withal, it is not necessary to work within release channels, and the user might 
 ```yaml
 - uses: werf/actions/build-and-publish@v1.1
   with:
-    version: v1.1.16
+    version: v1.1.23
 ```
 
 ### kubeconfig setup (*optional*)

--- a/build-and-publish/README.md
+++ b/build-and-publish/README.md
@@ -10,21 +10,20 @@ The action combines all the necessary steps in itself and logic may be divided i
 ### werf binary setup
  
 By default, all actions setup actual werf version for [1.1 alpha channel](https://werf.io/releases.html) (more details about channels, werf release cycle and compatibility promise [here](https://github.com/werf/werf#backward-compatibility-promise)). 
-Using `group` and `channel` inputs the user can switch the release channel.
+Using the `channel` input the user can switch the release channel.
 
 > This is recommended approach to be up-to-date and to use actual werf version without changing configurations
   
 ```yaml
-- uses: werf/actions/build-and-publish@master
+- uses: werf/actions/build-and-publish@v1.1
   with:
-    group: 1.1
     channel: alpha
 ```
   
 Withal, it is not necessary to work within release channels, and the user might specify certain werf version with `version` input.
 
 ```yaml
-- uses: werf/actions/build-and-publish@master
+- uses: werf/actions/build-and-publish@v1.1
   with:
     version: v1.1.16
 ```
@@ -38,7 +37,7 @@ The _kubeconfig_ may be used for deployment, cleanup, distributed locks and cach
 * Pass secret with `kube-config-base64-data` input:
  
   ```yaml
-  - uses: werf/actions/build-and-publish@master
+  - uses: werf/actions/build-and-publish@v1.1
     with:
       kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
   ```
@@ -56,7 +55,7 @@ By default, action will use the token provided to your workflow.
 Any werf option can be defined with environment variables:
 
 ```yaml
-- uses: werf/actions/build-and-publish@master
+- uses: werf/actions/build-and-publish@v1.1
   env:
     WERF_LOG_VERBOSE: "on"
     WERF_TAG_CUSTOM_TAG1: tag1
@@ -66,10 +65,6 @@ Any werf option can be defined with environment variables:
 ## Inputs
 
 ```yaml
-group:
-  description: 'The MAJOR.MINOR version'
-  default: '1.1'
-  required: false
 channel:
   description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
   default: 'alpha'
@@ -100,7 +95,7 @@ build-and-publish:
         fetch-depth: 0
 
     - name: Build and Publish  
-      uses: werf/actions/build-and-publish@master
+      uses: werf/actions/build-and-publish@v1.1
       with:
         kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
 ```

--- a/build-and-publish/action.yml
+++ b/build-and-publish/action.yml
@@ -5,10 +5,6 @@ branding:
   color: blue
   icon: anchor
 inputs:
-  group:
-    description: 'The MAJOR.MINOR version'
-    default: '1.1'
-    required: false
   channel:
     description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
     default: 'alpha'

--- a/build-and-publish/index.js
+++ b/build-and-publish/index.js
@@ -4167,7 +4167,19 @@ module.exports = gt
 
 
 /***/ }),
-/* 290 */,
+/* 290 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MINOR = exports.MAJOR = exports.MAJOR_MINOR_GROUP = void 0;
+exports.MAJOR_MINOR_GROUP = '1.1';
+exports.MAJOR = 1;
+exports.MINOR = 1;
+
+
+/***/ }),
 /* 291 */,
 /* 292 */,
 /* 293 */
@@ -11504,6 +11516,7 @@ const semver = __importStar(__webpack_require__(232));
 const github_1 = __webpack_require__(127);
 const typescript_string_operations_1 = __webpack_require__(863);
 const manager_1 = __webpack_require__(965);
+const werf = __importStar(__webpack_require__(290));
 const minimalWerfVersion = 'v1.1.17';
 function PrepareEnvironAndRunWerfCommand(args) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -11556,11 +11569,14 @@ exports.ProcessGitHubContext = ProcessGitHubContext;
 function ValidateWerfVersion(version) {
     const ver = semver.coerce(version);
     if (ver) {
+        if (ver.major !== werf.MAJOR || ver.minor !== werf.MINOR) {
+            throw new Error(typescript_string_operations_1.String.Format('The arbitrary version ({0}) must be within the MAJOR.MINOR ({1})', version.trim(), werf.MAJOR_MINOR_GROUP));
+        }
         if (semver.gte(ver, minimalWerfVersion)) {
             return;
         }
     }
-    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version should be equal or greater than {1})', version.trim(), minimalWerfVersion));
+    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version must be equal or greater than {1})', version.trim(), minimalWerfVersion));
 }
 exports.ValidateWerfVersion = ValidateWerfVersion;
 
@@ -43791,9 +43807,9 @@ const typescript_string_operations_1 = __webpack_require__(863);
 const crypto = __importStar(__webpack_require__(417));
 const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
+const werf = __importStar(__webpack_require__(290));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
-const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
         this.channel = core.getInput('channel').trim();
@@ -43877,7 +43893,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: MAJOR_MINOR_GROUP,
+                        group: werf.MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/build-and-publish/index.js
+++ b/build-and-publish/index.js
@@ -43793,9 +43793,9 @@ const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
+const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
-        this.group = core.getInput('group').trim();
         this.channel = core.getInput('channel').trim();
         this.version = core.getInput('version').trim();
         if (process.platform.toString() === 'win32') {
@@ -43877,7 +43877,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: this.group,
+                        group: MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/build/README.md
+++ b/build/README.md
@@ -10,21 +10,20 @@ The action combines all the necessary steps in itself and logic may be divided i
 ### werf binary setup
  
 By default, all actions setup actual werf version for [1.1 alpha channel](https://werf.io/releases.html) (more details about channels, werf release cycle and compatibility promise [here](https://github.com/werf/werf#backward-compatibility-promise)). 
-Using `group` and `channel` inputs the user can switch the release channel.
+Using the `channel` input the user can switch the release channel.
 
 > This is recommended approach to be up-to-date and to use actual werf version without changing configurations
   
 ```yaml
-- uses: werf/actions/build@master
+- uses: werf/actions/build@v1.1
   with:
-    group: 1.1
     channel: alpha
 ```
   
 Withal, it is not necessary to work within release channels, and the user might specify certain werf version with `version` input.
 
 ```yaml
-- uses: werf/actions/build@master
+- uses: werf/actions/build@v1.1
   with:
     version: v1.1.16
 ```
@@ -38,7 +37,7 @@ The _kubeconfig_ may be used for deployment, cleanup, distributed locks and cach
 * Pass secret with `kube-config-base64-data` input:
  
   ```yaml
-  - uses: werf/actions/build@master
+  - uses: werf/actions/build@v1.1
     with:
       kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
   ```
@@ -56,7 +55,7 @@ By default, action will use the token provided to your workflow.
 Any werf option can be defined with environment variables:
 
 ```yaml
-- uses: werf/actions/build@master
+- uses: werf/actions/build@v1.1
   env:
     WERF_LOG_VERBOSE: "on"
     WERF_TAG_CUSTOM_TAG1: tag1
@@ -66,10 +65,6 @@ Any werf option can be defined with environment variables:
 ## Inputs
 
 ```yaml
-group:
-  description: 'The MAJOR.MINOR version'
-  default: '1.1'
-  required: false
 channel:
   description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
   default: 'alpha'
@@ -100,7 +95,7 @@ build:
         fetch-depth: 0
 
     - name: Build
-      uses: werf/actions/build@master
+      uses: werf/actions/build@v1.1
       with:
         kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
 ```

--- a/build/README.md
+++ b/build/README.md
@@ -25,7 +25,7 @@ Withal, it is not necessary to work within release channels, and the user might 
 ```yaml
 - uses: werf/actions/build@v1.1
   with:
-    version: v1.1.16
+    version: v1.1.23
 ```
 
 ### kubeconfig setup (*optional*)

--- a/build/action.yml
+++ b/build/action.yml
@@ -5,10 +5,6 @@ branding:
   color: blue
   icon: anchor
 inputs:
-  group:
-    description: 'The MAJOR.MINOR version'
-    default: '1.1'
-    required: false
   channel:
     description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
     default: 'alpha'

--- a/build/index.js
+++ b/build/index.js
@@ -43793,9 +43793,9 @@ const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
+const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
-        this.group = core.getInput('group').trim();
         this.channel = core.getInput('channel').trim();
         this.version = core.getInput('version').trim();
         if (process.platform.toString() === 'win32') {
@@ -43877,7 +43877,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: this.group,
+                        group: MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/build/index.js
+++ b/build/index.js
@@ -4118,7 +4118,19 @@ module.exports = gt
 
 
 /***/ }),
-/* 290 */,
+/* 290 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MINOR = exports.MAJOR = exports.MAJOR_MINOR_GROUP = void 0;
+exports.MAJOR_MINOR_GROUP = '1.1';
+exports.MAJOR = 1;
+exports.MINOR = 1;
+
+
+/***/ }),
 /* 291 */,
 /* 292 */,
 /* 293 */
@@ -11455,6 +11467,7 @@ const semver = __importStar(__webpack_require__(232));
 const github_1 = __webpack_require__(127);
 const typescript_string_operations_1 = __webpack_require__(863);
 const manager_1 = __webpack_require__(965);
+const werf = __importStar(__webpack_require__(290));
 const minimalWerfVersion = 'v1.1.17';
 function PrepareEnvironAndRunWerfCommand(args) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -11507,11 +11520,14 @@ exports.ProcessGitHubContext = ProcessGitHubContext;
 function ValidateWerfVersion(version) {
     const ver = semver.coerce(version);
     if (ver) {
+        if (ver.major !== werf.MAJOR || ver.minor !== werf.MINOR) {
+            throw new Error(typescript_string_operations_1.String.Format('The arbitrary version ({0}) must be within the MAJOR.MINOR ({1})', version.trim(), werf.MAJOR_MINOR_GROUP));
+        }
         if (semver.gte(ver, minimalWerfVersion)) {
             return;
         }
     }
-    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version should be equal or greater than {1})', version.trim(), minimalWerfVersion));
+    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version must be equal or greater than {1})', version.trim(), minimalWerfVersion));
 }
 exports.ValidateWerfVersion = ValidateWerfVersion;
 
@@ -43791,9 +43807,9 @@ const typescript_string_operations_1 = __webpack_require__(863);
 const crypto = __importStar(__webpack_require__(417));
 const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
+const werf = __importStar(__webpack_require__(290));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
-const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
         this.channel = core.getInput('channel').trim();
@@ -43877,7 +43893,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: MAJOR_MINOR_GROUP,
+                        group: werf.MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/cleanup/README.md
+++ b/cleanup/README.md
@@ -10,21 +10,20 @@ The action combines all the necessary steps in itself and logic may be divided i
 ### werf binary setup
  
 By default, all actions setup actual werf version for [1.1 alpha channel](https://werf.io/releases.html) (more details about channels, werf release cycle and compatibility promise [here](https://github.com/werf/werf#backward-compatibility-promise)). 
-Using `group` and `channel` inputs the user can switch the release channel.
+Using the `channel` input the user can switch the release channel.
 
 > This is recommended approach to be up-to-date and to use actual werf version without changing configurations
   
 ```yaml
-- uses: werf/actions/cleanup@master
+- uses: werf/actions/cleanup@v1.1
   with:
-    group: 1.1
     channel: alpha
 ```
   
 Withal, it is not necessary to work within release channels, and the user might specify certain werf version with `version` input.
 
 ```yaml
-- uses: werf/actions/cleanup@master
+- uses: werf/actions/cleanup@v1.1
   with:
     version: v1.1.16
 ```
@@ -38,7 +37,7 @@ The _kubeconfig_ may be used for deployment, cleanup, distributed locks and cach
 * Pass secret with `kube-config-base64-data` input:
  
   ```yaml
-  - uses: werf/actions/cleanup@master
+  - uses: werf/actions/cleanup@v1.1
     with:
       kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
   ```
@@ -56,7 +55,7 @@ By default, action will use the token provided to your workflow.
 Any werf option can be defined with environment variables:
 
 ```yaml
-- uses: werf/actions/cleanup@master
+- uses: werf/actions/cleanup@v1.1
   env:
     WERF_LOG_VERBOSE: "on"
 ```
@@ -64,10 +63,6 @@ Any werf option can be defined with environment variables:
 ## Inputs
 
 ```yaml
-group:
-  description: 'The MAJOR.MINOR version'
-  default: '1.1'
-  required: false
 channel:
   description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
   default: 'alpha'
@@ -99,7 +94,7 @@ cleanup:
       run: git fetch --prune --unshallow
 
     - name: Cleanup
-      uses: werf/actions/cleanup@master
+      uses: werf/actions/cleanup@v1.1
       with:
         kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
 ```

--- a/cleanup/README.md
+++ b/cleanup/README.md
@@ -25,7 +25,7 @@ Withal, it is not necessary to work within release channels, and the user might 
 ```yaml
 - uses: werf/actions/cleanup@v1.1
   with:
-    version: v1.1.16
+    version: v1.1.23
 ```
 
 ### kubeconfig setup (*optional*)

--- a/cleanup/action.yml
+++ b/cleanup/action.yml
@@ -5,10 +5,6 @@ branding:
   color: blue
   icon: anchor
 inputs:
-  group:
-    description: 'The MAJOR.MINOR version'
-    default: '1.1'
-    required: false
   channel:
     description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
     default: 'alpha'

--- a/cleanup/index.js
+++ b/cleanup/index.js
@@ -43793,9 +43793,9 @@ const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
+const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
-        this.group = core.getInput('group').trim();
         this.channel = core.getInput('channel').trim();
         this.version = core.getInput('version').trim();
         if (process.platform.toString() === 'win32') {
@@ -43877,7 +43877,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: this.group,
+                        group: MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/cleanup/index.js
+++ b/cleanup/index.js
@@ -4118,7 +4118,19 @@ module.exports = gt
 
 
 /***/ }),
-/* 290 */,
+/* 290 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MINOR = exports.MAJOR = exports.MAJOR_MINOR_GROUP = void 0;
+exports.MAJOR_MINOR_GROUP = '1.1';
+exports.MAJOR = 1;
+exports.MINOR = 1;
+
+
+/***/ }),
 /* 291 */,
 /* 292 */,
 /* 293 */
@@ -11455,6 +11467,7 @@ const semver = __importStar(__webpack_require__(232));
 const github_1 = __webpack_require__(127);
 const typescript_string_operations_1 = __webpack_require__(863);
 const manager_1 = __webpack_require__(965);
+const werf = __importStar(__webpack_require__(290));
 const minimalWerfVersion = 'v1.1.17';
 function PrepareEnvironAndRunWerfCommand(args) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -11507,11 +11520,14 @@ exports.ProcessGitHubContext = ProcessGitHubContext;
 function ValidateWerfVersion(version) {
     const ver = semver.coerce(version);
     if (ver) {
+        if (ver.major !== werf.MAJOR || ver.minor !== werf.MINOR) {
+            throw new Error(typescript_string_operations_1.String.Format('The arbitrary version ({0}) must be within the MAJOR.MINOR ({1})', version.trim(), werf.MAJOR_MINOR_GROUP));
+        }
         if (semver.gte(ver, minimalWerfVersion)) {
             return;
         }
     }
-    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version should be equal or greater than {1})', version.trim(), minimalWerfVersion));
+    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version must be equal or greater than {1})', version.trim(), minimalWerfVersion));
 }
 exports.ValidateWerfVersion = ValidateWerfVersion;
 
@@ -43791,9 +43807,9 @@ const typescript_string_operations_1 = __webpack_require__(863);
 const crypto = __importStar(__webpack_require__(417));
 const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
+const werf = __importStar(__webpack_require__(290));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
-const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
         this.channel = core.getInput('channel').trim();
@@ -43877,7 +43893,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: MAJOR_MINOR_GROUP,
+                        group: werf.MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/converge/README.md
+++ b/converge/README.md
@@ -10,21 +10,20 @@ The action combines all the necessary steps in itself and logic may be divided i
 ### werf binary setup
  
 By default, all actions setup actual werf version for [1.1 alpha channel](https://werf.io/releases.html) (more details about channels, werf release cycle and compatibility promise [here](https://github.com/werf/werf#backward-compatibility-promise)). 
-Using `group` and `channel` inputs the user can switch the release channel.
+Using the `channel` input the user can switch the release channel.
 
 > This is recommended approach to be up-to-date and to use actual werf version without changing configurations
   
 ```yaml
-- uses: werf/actions/converge@master
+- uses: werf/actions/converge@v1.1
   with:
-    group: 1.1
     channel: alpha
 ```
   
 Withal, it is not necessary to work within release channels, and the user might specify certain werf version with `version` input.
 
 ```yaml
-- uses: werf/actions/converge@master
+- uses: werf/actions/converge@v1.1
   with:
     version: v1.1.16
 ```
@@ -38,7 +37,7 @@ The _kubeconfig_ may be used for deployment, cleanup, distributed locks and cach
 * Pass secret with `kube-config-base64-data` input:
  
   ```yaml
-  - uses: werf/actions/converge@master
+  - uses: werf/actions/converge@v1.1
     with:
       kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
   ```
@@ -56,7 +55,7 @@ By default, action will use the token provided to your workflow.
 Any werf option can be defined with environment variables:
 
 ```yaml
-- uses: werf/actions/converge@master
+- uses: werf/actions/converge@v1.1
   with:
     env: production
   env:
@@ -66,10 +65,6 @@ Any werf option can be defined with environment variables:
 ## Inputs
 
 ```yaml
-group:
-  description: 'The MAJOR.MINOR version'
-  default: '1.1'
-  required: false
 channel:
   description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
   default: 'alpha'
@@ -103,7 +98,7 @@ converge:
         fetch-depth: 0
 
     - name: Converge
-      uses: werf/actions/converge@master
+      uses: werf/actions/converge@v1.1
       with:
         kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
         env: production

--- a/converge/README.md
+++ b/converge/README.md
@@ -25,7 +25,7 @@ Withal, it is not necessary to work within release channels, and the user might 
 ```yaml
 - uses: werf/actions/converge@v1.1
   with:
-    version: v1.1.16
+    version: v1.1.23
 ```
 
 ### kubeconfig setup (*optional*)

--- a/converge/action.yml
+++ b/converge/action.yml
@@ -5,10 +5,6 @@ branding:
   color: blue
   icon: anchor
 inputs:
-  group:
-    description: 'The MAJOR.MINOR version'
-    default: '1.1'
-    required: false
   channel:
     description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
     default: 'alpha'

--- a/converge/index.js
+++ b/converge/index.js
@@ -4118,7 +4118,19 @@ module.exports = gt
 
 
 /***/ }),
-/* 290 */,
+/* 290 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MINOR = exports.MAJOR = exports.MAJOR_MINOR_GROUP = void 0;
+exports.MAJOR_MINOR_GROUP = '1.1';
+exports.MAJOR = 1;
+exports.MINOR = 1;
+
+
+/***/ }),
 /* 291 */,
 /* 292 */,
 /* 293 */
@@ -11455,6 +11467,7 @@ const semver = __importStar(__webpack_require__(232));
 const github_1 = __webpack_require__(127);
 const typescript_string_operations_1 = __webpack_require__(863);
 const manager_1 = __webpack_require__(965);
+const werf = __importStar(__webpack_require__(290));
 const minimalWerfVersion = 'v1.1.17';
 function PrepareEnvironAndRunWerfCommand(args) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -11507,11 +11520,14 @@ exports.ProcessGitHubContext = ProcessGitHubContext;
 function ValidateWerfVersion(version) {
     const ver = semver.coerce(version);
     if (ver) {
+        if (ver.major !== werf.MAJOR || ver.minor !== werf.MINOR) {
+            throw new Error(typescript_string_operations_1.String.Format('The arbitrary version ({0}) must be within the MAJOR.MINOR ({1})', version.trim(), werf.MAJOR_MINOR_GROUP));
+        }
         if (semver.gte(ver, minimalWerfVersion)) {
             return;
         }
     }
-    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version should be equal or greater than {1})', version.trim(), minimalWerfVersion));
+    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version must be equal or greater than {1})', version.trim(), minimalWerfVersion));
 }
 exports.ValidateWerfVersion = ValidateWerfVersion;
 
@@ -43792,9 +43808,9 @@ const typescript_string_operations_1 = __webpack_require__(863);
 const crypto = __importStar(__webpack_require__(417));
 const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
+const werf = __importStar(__webpack_require__(290));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
-const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
         this.channel = core.getInput('channel').trim();
@@ -43878,7 +43894,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: MAJOR_MINOR_GROUP,
+                        group: werf.MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/converge/index.js
+++ b/converge/index.js
@@ -43794,9 +43794,9 @@ const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
+const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
-        this.group = core.getInput('group').trim();
         this.channel = core.getInput('channel').trim();
         this.version = core.getInput('version').trim();
         if (process.platform.toString() === 'win32') {
@@ -43878,7 +43878,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: this.group,
+                        group: MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,21 +10,20 @@ The action combines all the necessary steps in itself and logic may be divided i
 ### werf binary setup
  
 By default, all actions setup actual werf version for [1.1 alpha channel](https://werf.io/releases.html) (more details about channels, werf release cycle and compatibility promise [here](https://github.com/werf/werf#backward-compatibility-promise)). 
-Using `group` and `channel` inputs the user can switch the release channel.
+Using the `channel` input the user can switch the release channel.
 
 > This is recommended approach to be up-to-date and to use actual werf version without changing configurations
   
 ```yaml
-- uses: werf/actions/deploy@master
+- uses: werf/actions/deploy@v1.1
   with:
-    group: 1.1
     channel: alpha
 ```
   
 Withal, it is not necessary to work within release channels, and the user might specify certain werf version with `version` input.
 
 ```yaml
-- uses: werf/actions/deploy@master
+- uses: werf/actions/deploy@v1.1
   with:
     version: v1.1.16
 ```
@@ -38,7 +37,7 @@ The _kubeconfig_ may be used for deployment, cleanup, distributed locks and cach
 * Pass secret with `kube-config-base64-data` input:
  
   ```yaml
-  - uses: werf/actions/deploy@master
+  - uses: werf/actions/deploy@v1.1
     with:
       kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
   ```
@@ -56,7 +55,7 @@ By default, action will use the token provided to your workflow.
 Any werf option can be defined with environment variables:
 
 ```yaml
-- uses: werf/actions/deploy@master
+- uses: werf/actions/deploy@v1.1
   with:
     env: production
   env:
@@ -66,10 +65,6 @@ Any werf option can be defined with environment variables:
 ## Inputs
 
 ```yaml
-group:
-  description: 'The MAJOR.MINOR version'
-  default: '1.1'
-  required: false
 channel:
   description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
   default: 'alpha'
@@ -103,7 +98,7 @@ deploy:
         fetch-depth: 0
 
     - name: Deploy
-      uses: werf/actions/deploy@master
+      uses: werf/actions/deploy@v1.1
       with:
         kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
         env: production

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,7 +25,7 @@ Withal, it is not necessary to work within release channels, and the user might 
 ```yaml
 - uses: werf/actions/deploy@v1.1
   with:
-    version: v1.1.16
+    version: v1.1.23
 ```
 
 ### kubeconfig setup (*optional*)

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -5,10 +5,6 @@ branding:
   color: blue
   icon: anchor
 inputs:
-  group:
-    description: 'The MAJOR.MINOR version'
-    default: '1.1'
-    required: false
   channel:
     description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
     default: 'alpha'

--- a/deploy/index.js
+++ b/deploy/index.js
@@ -4118,7 +4118,19 @@ module.exports = gt
 
 
 /***/ }),
-/* 290 */,
+/* 290 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MINOR = exports.MAJOR = exports.MAJOR_MINOR_GROUP = void 0;
+exports.MAJOR_MINOR_GROUP = '1.1';
+exports.MAJOR = 1;
+exports.MINOR = 1;
+
+
+/***/ }),
 /* 291 */,
 /* 292 */,
 /* 293 */
@@ -11455,6 +11467,7 @@ const semver = __importStar(__webpack_require__(232));
 const github_1 = __webpack_require__(127);
 const typescript_string_operations_1 = __webpack_require__(863);
 const manager_1 = __webpack_require__(965);
+const werf = __importStar(__webpack_require__(290));
 const minimalWerfVersion = 'v1.1.17';
 function PrepareEnvironAndRunWerfCommand(args) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -11507,11 +11520,14 @@ exports.ProcessGitHubContext = ProcessGitHubContext;
 function ValidateWerfVersion(version) {
     const ver = semver.coerce(version);
     if (ver) {
+        if (ver.major !== werf.MAJOR || ver.minor !== werf.MINOR) {
+            throw new Error(typescript_string_operations_1.String.Format('The arbitrary version ({0}) must be within the MAJOR.MINOR ({1})', version.trim(), werf.MAJOR_MINOR_GROUP));
+        }
         if (semver.gte(ver, minimalWerfVersion)) {
             return;
         }
     }
-    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version should be equal or greater than {1})', version.trim(), minimalWerfVersion));
+    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version must be equal or greater than {1})', version.trim(), minimalWerfVersion));
 }
 exports.ValidateWerfVersion = ValidateWerfVersion;
 
@@ -43756,9 +43772,9 @@ const typescript_string_operations_1 = __webpack_require__(863);
 const crypto = __importStar(__webpack_require__(417));
 const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
+const werf = __importStar(__webpack_require__(290));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
-const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
         this.channel = core.getInput('channel').trim();
@@ -43842,7 +43858,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: MAJOR_MINOR_GROUP,
+                        group: werf.MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/deploy/index.js
+++ b/deploy/index.js
@@ -43758,9 +43758,9 @@ const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
+const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
-        this.group = core.getInput('group').trim();
         this.channel = core.getInput('channel').trim();
         this.version = core.getInput('version').trim();
         if (process.platform.toString() === 'win32') {
@@ -43842,7 +43842,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: this.group,
+                        group: MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/dismiss/README.md
+++ b/dismiss/README.md
@@ -10,21 +10,20 @@ The action combines all the necessary steps in itself and logic may be divided i
 ### werf binary setup
  
 By default, all actions setup actual werf version for [1.1 alpha channel](https://werf.io/releases.html) (more details about channels, werf release cycle and compatibility promise [here](https://github.com/werf/werf#backward-compatibility-promise)). 
-Using `group` and `channel` inputs the user can switch the release channel.
+Using the `channel` input the user can switch the release channel.
 
 > This is recommended approach to be up-to-date and to use actual werf version without changing configurations
   
 ```yaml
-- uses: werf/actions/converge@master
+- uses: werf/actions/converge@v1.1
   with:
-    group: 1.1
     channel: alpha
 ```
   
 Withal, it is not necessary to work within release channels, and the user might specify certain werf version with `version` input.
 
 ```yaml
-- uses: werf/actions/converge@master
+- uses: werf/actions/converge@v1.1
   with:
     version: v1.1.16
 ```
@@ -38,7 +37,7 @@ The _kubeconfig_ may be used for deployment, cleanup, distributed locks and cach
 * Pass secret with `kube-config-base64-data` input:
  
   ```yaml
-  - uses: werf/actions/converge@master
+  - uses: werf/actions/converge@v1.1
     with:
       kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
   ```
@@ -56,7 +55,7 @@ By default, action will use the token provided to your workflow.
 Any werf option can be defined with environment variables:
 
 ```yaml
-- uses: werf/actions/converge@master
+- uses: werf/actions/converge@v1.1
   with:
     env: production
   env:
@@ -66,10 +65,6 @@ Any werf option can be defined with environment variables:
 ## Inputs
 
 ```yaml
-group:
-  description: 'The MAJOR.MINOR version'
-  default: '1.1'
-  required: false
 channel:
   description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
   default: 'alpha'
@@ -101,7 +96,7 @@ dismiss:
       uses: actions/checkout@v2
 
     - name: Dismiss
-      uses: werf/actions/dismiss@master
+      uses: werf/actions/dismiss@v1.1
       with:
         kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
         env: production

--- a/dismiss/README.md
+++ b/dismiss/README.md
@@ -25,7 +25,7 @@ Withal, it is not necessary to work within release channels, and the user might 
 ```yaml
 - uses: werf/actions/converge@v1.1
   with:
-    version: v1.1.16
+    version: v1.1.23
 ```
 
 ### kubeconfig setup (*optional*)

--- a/dismiss/action.yml
+++ b/dismiss/action.yml
@@ -5,10 +5,6 @@ branding:
   color: blue
   icon: anchor
 inputs:
-  group:
-    description: 'The MAJOR.MINOR version'
-    default: '1.1'
-    required: false
   channel:
     description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
     default: 'alpha'

--- a/dismiss/index.js
+++ b/dismiss/index.js
@@ -4118,7 +4118,19 @@ module.exports = gt
 
 
 /***/ }),
-/* 290 */,
+/* 290 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MINOR = exports.MAJOR = exports.MAJOR_MINOR_GROUP = void 0;
+exports.MAJOR_MINOR_GROUP = '1.1';
+exports.MAJOR = 1;
+exports.MINOR = 1;
+
+
+/***/ }),
 /* 291 */,
 /* 292 */,
 /* 293 */
@@ -11505,6 +11517,7 @@ const semver = __importStar(__webpack_require__(232));
 const github_1 = __webpack_require__(127);
 const typescript_string_operations_1 = __webpack_require__(863);
 const manager_1 = __webpack_require__(965);
+const werf = __importStar(__webpack_require__(290));
 const minimalWerfVersion = 'v1.1.17';
 function PrepareEnvironAndRunWerfCommand(args) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -11557,11 +11570,14 @@ exports.ProcessGitHubContext = ProcessGitHubContext;
 function ValidateWerfVersion(version) {
     const ver = semver.coerce(version);
     if (ver) {
+        if (ver.major !== werf.MAJOR || ver.minor !== werf.MINOR) {
+            throw new Error(typescript_string_operations_1.String.Format('The arbitrary version ({0}) must be within the MAJOR.MINOR ({1})', version.trim(), werf.MAJOR_MINOR_GROUP));
+        }
         if (semver.gte(ver, minimalWerfVersion)) {
             return;
         }
     }
-    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version should be equal or greater than {1})', version.trim(), minimalWerfVersion));
+    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version must be equal or greater than {1})', version.trim(), minimalWerfVersion));
 }
 exports.ValidateWerfVersion = ValidateWerfVersion;
 
@@ -43792,9 +43808,9 @@ const typescript_string_operations_1 = __webpack_require__(863);
 const crypto = __importStar(__webpack_require__(417));
 const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
+const werf = __importStar(__webpack_require__(290));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
-const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
         this.channel = core.getInput('channel').trim();
@@ -43878,7 +43894,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: MAJOR_MINOR_GROUP,
+                        group: werf.MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/dismiss/index.js
+++ b/dismiss/index.js
@@ -43794,9 +43794,9 @@ const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
+const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
-        this.group = core.getInput('group').trim();
         this.channel = core.getInput('channel').trim();
         this.version = core.getInput('version').trim();
         if (process.platform.toString() === 'win32') {
@@ -43878,7 +43878,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: this.group,
+                        group: MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/install/README.md
+++ b/install/README.md
@@ -4,21 +4,20 @@
 ___
  
 By default, all actions setup actual werf version for [1.1 alpha channel](https://werf.io/releases.html) (more details about channels, werf release cycle and compatibility promise [here](https://github.com/werf/werf#backward-compatibility-promise)). 
-Using `group` and `channel` inputs the user can switch the release channel.
+Using the `channel` input the user can switch the release channel.
 
 > This is recommended approach to be up-to-date and to use actual werf version without changing configurations
   
 ```yaml
-- uses: werf/actions/install@master
+- uses: werf/actions/install@v1.1
   with:
-    group: 1.1
     channel: alpha
 ```
   
 Withal, it is not necessary to work within release channels, and the user might specify certain werf version with `version` input.
 
 ```yaml
-- uses: werf/actions/install@master
+- uses: werf/actions/install@v1.1
   with:
     version: v1.1.16
 ```
@@ -26,10 +25,6 @@ Withal, it is not necessary to work within release channels, and the user might 
 ## Inputs
 
 ```yaml
-group:
-  description: 'The MAJOR.MINOR version'
-  default: '1.1'
-  required: false
 channel:
   description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
   default: 'alpha'
@@ -48,10 +43,10 @@ werf:
   steps:
   
     - name: Checkout code  
-      uses: actions/checkout@master
+      uses: actions/checkout@v1.1
 
     - name: Install werf CLI  
-      uses: werf/actions/install@master
+      uses: werf/actions/install@v1.1
     
     # for deploy and distributed locks
     - name: Create kube config

--- a/install/README.md
+++ b/install/README.md
@@ -19,7 +19,7 @@ Withal, it is not necessary to work within release channels, and the user might 
 ```yaml
 - uses: werf/actions/install@v1.1
   with:
-    version: v1.1.16
+    version: v1.1.23
 ```
 
 ## Inputs

--- a/install/action.yml
+++ b/install/action.yml
@@ -5,10 +5,6 @@ branding:
   color: blue
   icon: anchor
 inputs:
-  group:
-    description: 'The MAJOR.MINOR version'
-    default: '1.1'
-    required: false
   channel:
     description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
     default: 'alpha'

--- a/install/index.js
+++ b/install/index.js
@@ -17330,9 +17330,9 @@ const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(646));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
+const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
-        this.group = core.getInput('group').trim();
         this.channel = core.getInput('channel').trim();
         this.version = core.getInput('version').trim();
         if (process.platform.toString() === 'win32') {
@@ -17414,7 +17414,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: this.group,
+                        group: MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/install/index.js
+++ b/install/index.js
@@ -1882,6 +1882,20 @@ exports._readLinuxVersionFile = _readLinuxVersionFile;
 
 /***/ }),
 
+/***/ 290:
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MINOR = exports.MAJOR = exports.MAJOR_MINOR_GROUP = void 0;
+exports.MAJOR_MINOR_GROUP = '1.1';
+exports.MAJOR = 1;
+exports.MINOR = 1;
+
+
+/***/ }),
+
 /***/ 293:
 /***/ (function(module) {
 
@@ -17328,9 +17342,9 @@ const typescript_string_operations_1 = __webpack_require__(863);
 const crypto = __importStar(__webpack_require__(417));
 const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(646));
+const werf = __importStar(__webpack_require__(290));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
-const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
         this.channel = core.getInput('channel').trim();
@@ -17414,7 +17428,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: MAJOR_MINOR_GROUP,
+                        group: werf.MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "werf-actions",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "lib",
   "dependencies": {

--- a/publish/README.md
+++ b/publish/README.md
@@ -25,7 +25,7 @@ Withal, it is not necessary to work within release channels, and the user might 
 ```yaml
 - uses: werf/actions/publish@v1.1
   with:
-    version: v1.1.16
+    version: v1.1.23
 ```
 
 ### kubeconfig setup (*optional*)

--- a/publish/README.md
+++ b/publish/README.md
@@ -10,21 +10,20 @@ The action combines all the necessary steps in itself and logic may be divided i
 ### werf binary setup
  
 By default, all actions setup actual werf version for [1.1 alpha channel](https://werf.io/releases.html) (more details about channels, werf release cycle and compatibility promise [here](https://github.com/werf/werf#backward-compatibility-promise)). 
-Using `group` and `channel` inputs the user can switch the release channel.
+Using the `channel` input the user can switch the release channel.
 
 > This is recommended approach to be up-to-date and to use actual werf version without changing configurations
   
 ```yaml
-- uses: werf/actions/publish@master
+- uses: werf/actions/publish@v1.1
   with:
-    group: 1.1
     channel: alpha
 ```
   
 Withal, it is not necessary to work within release channels, and the user might specify certain werf version with `version` input.
 
 ```yaml
-- uses: werf/actions/publish@master
+- uses: werf/actions/publish@v1.1
   with:
     version: v1.1.16
 ```
@@ -38,7 +37,7 @@ The _kubeconfig_ may be used for deployment, cleanup, distributed locks and cach
 * Pass secret with `kube-config-base64-data` input:
  
   ```yaml
-  - uses: werf/actions/publish@master
+  - uses: werf/actions/publish@v1.1
     with:
       kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
   ```
@@ -56,7 +55,7 @@ By default, action will use the token provided to your workflow.
 Any werf option can be defined with environment variables:
 
 ```yaml
-- uses: werf/actions/publish@master
+- uses: werf/actions/publish@v1.1
   env:
     WERF_LOG_VERBOSE: "on"
     WERF_TAG_CUSTOM_TAG1: tag1
@@ -66,10 +65,6 @@ Any werf option can be defined with environment variables:
 ## Inputs
 
 ```yaml
-group:
-  description: 'The MAJOR.MINOR version'
-  default: '1.1'
-  required: false
 channel:
   description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
   default: 'alpha'
@@ -100,7 +95,7 @@ publish:
         fetch-depth: 0
 
     - name: Publish
-      uses: werf/actions/publish@master
+      uses: werf/actions/publish@v1.1
       with:
         kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
 ```

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -5,10 +5,6 @@ branding:
   color: blue
   icon: anchor
 inputs:
-  group:
-    description: 'The MAJOR.MINOR version'
-    default: '1.1'
-    required: false
   channel:
     description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
     default: 'alpha'

--- a/publish/index.js
+++ b/publish/index.js
@@ -43793,9 +43793,9 @@ const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
+const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
-        this.group = core.getInput('group').trim();
         this.channel = core.getInput('channel').trim();
         this.version = core.getInput('version').trim();
         if (process.platform.toString() === 'win32') {
@@ -43877,7 +43877,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: this.group,
+                        group: MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/publish/index.js
+++ b/publish/index.js
@@ -4118,7 +4118,19 @@ module.exports = gt
 
 
 /***/ }),
-/* 290 */,
+/* 290 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MINOR = exports.MAJOR = exports.MAJOR_MINOR_GROUP = void 0;
+exports.MAJOR_MINOR_GROUP = '1.1';
+exports.MAJOR = 1;
+exports.MINOR = 1;
+
+
+/***/ }),
 /* 291 */,
 /* 292 */,
 /* 293 */
@@ -11455,6 +11467,7 @@ const semver = __importStar(__webpack_require__(232));
 const github_1 = __webpack_require__(127);
 const typescript_string_operations_1 = __webpack_require__(863);
 const manager_1 = __webpack_require__(965);
+const werf = __importStar(__webpack_require__(290));
 const minimalWerfVersion = 'v1.1.17';
 function PrepareEnvironAndRunWerfCommand(args) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -11507,11 +11520,14 @@ exports.ProcessGitHubContext = ProcessGitHubContext;
 function ValidateWerfVersion(version) {
     const ver = semver.coerce(version);
     if (ver) {
+        if (ver.major !== werf.MAJOR || ver.minor !== werf.MINOR) {
+            throw new Error(typescript_string_operations_1.String.Format('The arbitrary version ({0}) must be within the MAJOR.MINOR ({1})', version.trim(), werf.MAJOR_MINOR_GROUP));
+        }
         if (semver.gte(ver, minimalWerfVersion)) {
             return;
         }
     }
-    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version should be equal or greater than {1})', version.trim(), minimalWerfVersion));
+    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version must be equal or greater than {1})', version.trim(), minimalWerfVersion));
 }
 exports.ValidateWerfVersion = ValidateWerfVersion;
 
@@ -43791,9 +43807,9 @@ const typescript_string_operations_1 = __webpack_require__(863);
 const crypto = __importStar(__webpack_require__(417));
 const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
+const werf = __importStar(__webpack_require__(290));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
-const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
         this.channel = core.getInput('channel').trim();
@@ -43877,7 +43893,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: MAJOR_MINOR_GROUP,
+                        group: werf.MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/run/README.md
+++ b/run/README.md
@@ -10,21 +10,20 @@ The action combines all the necessary steps in itself and logic may be divided i
 ### werf binary setup
  
 By default, all actions setup actual werf version for [1.1 alpha channel](https://werf.io/releases.html) (more details about channels, werf release cycle and compatibility promise [here](https://github.com/werf/werf#backward-compatibility-promise)). 
-Using `group` and `channel` inputs the user can switch the release channel.
+Using the `channel` input the user can switch the release channel.
 
 > This is recommended approach to be up-to-date and to use actual werf version without changing configurations
   
 ```yaml
-- uses: werf/actions/run@master
+- uses: werf/actions/run@v1.1
   with:
-    group: 1.1
     channel: alpha
 ```
   
 Withal, it is not necessary to work within release channels, and the user might specify certain werf version with `version` input.
 
 ```yaml
-- uses: werf/actions/run@master
+- uses: werf/actions/run@v1.1
   with:
     version: v1.1.16
 ```
@@ -38,7 +37,7 @@ The _kubeconfig_ may be used for deployment, cleanup, distributed locks and cach
 * Pass secret with `kube-config-base64-data` input:
  
   ```yaml
-  - uses: werf/actions/run@master
+  - uses: werf/actions/run@v1.1
     with:
       kube-config-base64-data: ${{ secrets.KUBE_CONFIG_BASE64_DATA }}
   ```
@@ -56,7 +55,7 @@ By default, action will use the token provided to your workflow.
 Any werf option can be defined with environment variables:
 
 ```yaml
-- uses: werf/actions/run@master
+- uses: werf/actions/run@v1.1
   env:
     WERF_LOG_VERBOSE: "on"
     WERF_TAG_CUSTOM_TAG1: tag1
@@ -67,10 +66,6 @@ Any werf option can be defined with environment variables:
 
 ```yaml
 inputs:
-  group:
-    description: 'The MAJOR.MINOR version'
-    default: '1.1'
-    required: false
   channel:
     description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
     default: 'alpha'
@@ -107,7 +102,7 @@ run:
         fetch-depth: 0
 
     - name: Run
-      uses: werf/actions/run@master
+      uses: werf/actions/run@v1.1
       with:
         image: backend
         args: rails server

--- a/run/README.md
+++ b/run/README.md
@@ -25,7 +25,7 @@ Withal, it is not necessary to work within release channels, and the user might 
 ```yaml
 - uses: werf/actions/run@v1.1
   with:
-    version: v1.1.16
+    version: v1.1.23
 ```
 
 ### kubeconfig setup (*optional*)

--- a/run/action.yml
+++ b/run/action.yml
@@ -5,10 +5,6 @@ branding:
   color: blue
   icon: anchor
 inputs:
-  group:
-    description: 'The MAJOR.MINOR version'
-    default: '1.1'
-    required: false
   channel:
     description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
     default: 'alpha'

--- a/run/index.js
+++ b/run/index.js
@@ -43866,9 +43866,9 @@ const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
+const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
-        this.group = core.getInput('group').trim();
         this.channel = core.getInput('channel').trim();
         this.version = core.getInput('version').trim();
         if (process.platform.toString() === 'win32') {
@@ -43950,7 +43950,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: this.group,
+                        group: MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/run/index.js
+++ b/run/index.js
@@ -4240,7 +4240,19 @@ module.exports = gt
 
 
 /***/ }),
-/* 290 */,
+/* 290 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MINOR = exports.MAJOR = exports.MAJOR_MINOR_GROUP = void 0;
+exports.MAJOR_MINOR_GROUP = '1.1';
+exports.MAJOR = 1;
+exports.MINOR = 1;
+
+
+/***/ }),
 /* 291 */,
 /* 292 */,
 /* 293 */
@@ -11577,6 +11589,7 @@ const semver = __importStar(__webpack_require__(232));
 const github_1 = __webpack_require__(127);
 const typescript_string_operations_1 = __webpack_require__(863);
 const manager_1 = __webpack_require__(965);
+const werf = __importStar(__webpack_require__(290));
 const minimalWerfVersion = 'v1.1.17';
 function PrepareEnvironAndRunWerfCommand(args) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -11629,11 +11642,14 @@ exports.ProcessGitHubContext = ProcessGitHubContext;
 function ValidateWerfVersion(version) {
     const ver = semver.coerce(version);
     if (ver) {
+        if (ver.major !== werf.MAJOR || ver.minor !== werf.MINOR) {
+            throw new Error(typescript_string_operations_1.String.Format('The arbitrary version ({0}) must be within the MAJOR.MINOR ({1})', version.trim(), werf.MAJOR_MINOR_GROUP));
+        }
         if (semver.gte(ver, minimalWerfVersion)) {
             return;
         }
     }
-    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version should be equal or greater than {1})', version.trim(), minimalWerfVersion));
+    throw new Error(typescript_string_operations_1.String.Format('werf version {0} is not supported (expected version must be equal or greater than {1})', version.trim(), minimalWerfVersion));
 }
 exports.ValidateWerfVersion = ValidateWerfVersion;
 
@@ -43864,9 +43880,9 @@ const typescript_string_operations_1 = __webpack_require__(863);
 const crypto = __importStar(__webpack_require__(417));
 const tmp = __importStar(__webpack_require__(801));
 const dotenv = __importStar(__webpack_require__(972));
+const werf = __importStar(__webpack_require__(290));
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD = 'https://werf.io/api/getChannelVersionURL';
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL';
-const MAJOR_MINOR_GROUP = '1.1';
 class Manager {
     constructor() {
         this.channel = core.getInput('channel').trim();
@@ -43950,7 +43966,7 @@ class Manager {
                 else {
                     url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD;
                     query = {
-                        group: MAJOR_MINOR_GROUP,
+                        group: werf.MAJOR_MINOR_GROUP,
                         channel: this.channel,
                         os: this.os,
                         arch: this.arch

--- a/src/common.ts
+++ b/src/common.ts
@@ -5,6 +5,7 @@ import * as semver from 'semver'
 import {context} from '@actions/github'
 import {String} from 'typescript-string-operations'
 import {Manager} from './manager'
+import * as werf from './werf'
 
 const minimalWerfVersion = 'v1.1.17'
 
@@ -66,6 +67,16 @@ export function ProcessGitHubContext(): void {
 export function ValidateWerfVersion(version: string): void {
   const ver = semver.coerce(version)
   if (ver) {
+    if (ver.major !== werf.MAJOR || ver.minor !== werf.MINOR) {
+      throw new Error(
+        String.Format(
+          'The arbitrary version ({0}) must be within the MAJOR.MINOR ({1})',
+          version.trim(),
+          werf.MAJOR_MINOR_GROUP
+        )
+      )
+    }
+
     if (semver.gte(ver, minimalWerfVersion)) {
       return
     }
@@ -73,7 +84,7 @@ export function ValidateWerfVersion(version: string): void {
 
   throw new Error(
     String.Format(
-      'werf version {0} is not supported (expected version should be equal or greater than {1})',
+      'werf version {0} is not supported (expected version must be equal or greater than {1})',
       version.trim(),
       minimalWerfVersion
     )

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -13,9 +13,9 @@ import * as dotenv from 'dotenv'
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD =
   'https://werf.io/api/getChannelVersionURL'
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL'
+const MAJOR_MINOR_GROUP = '1.1'
 
 export class Manager {
-  private readonly group: string
   private readonly channel: string
   private readonly version: string
   private readonly os: string
@@ -24,7 +24,6 @@ export class Manager {
   private binaryPath: string | undefined
 
   constructor() {
-    this.group = core.getInput('group').trim()
     this.channel = core.getInput('channel').trim()
     this.version = core.getInput('version').trim()
 
@@ -113,7 +112,7 @@ export class Manager {
       } else {
         url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD
         query = {
-          group: this.group,
+          group: MAJOR_MINOR_GROUP,
           channel: this.channel,
           os: this.os,
           arch: this.arch

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -9,11 +9,11 @@ import {String} from 'typescript-string-operations'
 import * as crypto from 'crypto'
 import * as tmp from 'tmp'
 import * as dotenv from 'dotenv'
+import * as werf from './werf'
 
 const WERF_API_GET_CHANNEL_VERSION_URL_METHOD =
   'https://werf.io/api/getChannelVersionURL'
 const WERF_API_GET_VERSION_URL_METHOD = 'https://werf.io/api/getVersionURL'
-const MAJOR_MINOR_GROUP = '1.1'
 
 export class Manager {
   private readonly channel: string
@@ -112,7 +112,7 @@ export class Manager {
       } else {
         url = WERF_API_GET_CHANNEL_VERSION_URL_METHOD
         query = {
-          group: MAJOR_MINOR_GROUP,
+          group: werf.MAJOR_MINOR_GROUP,
           channel: this.channel,
           os: this.os,
           arch: this.arch

--- a/src/werf.ts
+++ b/src/werf.ts
@@ -1,0 +1,3 @@
+export const MAJOR_MINOR_GROUP = '1.1'
+export const MAJOR = 1
+export const MINOR = 1


### PR DESCRIPTION
- remove the `group` input
- embed the `MAJOR.MINOR` version in actions
- validate an arbitrary version: the version must be within `MAJOR.MINOR`