### PR TITLE
feat(action): use node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ inputs:
     description: 'Base64 encoded kubeconfig data used for deployment, cleanup and distributed locks'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'converge/index.js'

--- a/build/action.yml
+++ b/build/action.yml
@@ -20,5 +20,5 @@ inputs:
     description: 'Base64 encoded kubeconfig data used for deployment, cleanup and distributed locks'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/cleanup/action.yml
+++ b/cleanup/action.yml
@@ -20,5 +20,5 @@ inputs:
     description: 'Base64 encoded kubeconfig data used for deployment, cleanup and distributed locks'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/converge/action.yml
+++ b/converge/action.yml
@@ -23,5 +23,5 @@ inputs:
     description: 'Base64 encoded kubeconfig data used for deployment, cleanup and distributed locks'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/dismiss/action.yml
+++ b/dismiss/action.yml
@@ -23,5 +23,5 @@ inputs:
     description: 'Base64 encoded kubeconfig data used for deployment, cleanup and distributed locks'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/install/action.yml
+++ b/install/action.yml
@@ -17,5 +17,5 @@ inputs:
     default: '0'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/run/action.yml
+++ b/run/action.yml
@@ -26,5 +26,5 @@ inputs:
     description: 'Base64 encoded kubeconfig data used for deployment, cleanup and distributed locks'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/