### PR TITLE
chore(actions): update Node.js runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ inputs:
     description: 'Base64 encoded kubeconfig data used for deployment, cleanup and distributed locks'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'converge/index.js'

--- a/build/action.yml
+++ b/build/action.yml
@@ -20,5 +20,5 @@ inputs:
     description: 'Base64 encoded kubeconfig data used for deployment, cleanup and distributed locks'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'

--- a/cleanup/action.yml
+++ b/cleanup/action.yml
@@ -20,5 +20,5 @@ inputs:
     description: 'Base64 encoded kubeconfig data used for deployment, cleanup and distributed locks'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'

--- a/converge/action.yml
+++ b/converge/action.yml
@@ -24,5 +24,5 @@ inputs:
     description: 'Base64 encoded kubeconfig data used for deployment, cleanup and distributed locks'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'

--- a/dismiss/action.yml
+++ b/dismiss/action.yml
@@ -24,5 +24,5 @@ inputs:
     description: 'Base64 encoded kubeconfig data used for deployment, cleanup and distributed locks'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'

--- a/install/action.yml
+++ b/install/action.yml
@@ -17,5 +17,5 @@ inputs:
     default: '0'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'

--- a/run/action.yml
+++ b/run/action.yml
@@ -26,5 +26,5 @@ inputs:
     description: 'Base64 encoded kubeconfig data used for deployment, cleanup and distributed locks'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'


### PR DESCRIPTION
## Summary
- Update all `action.yml` files to use `node24` runtime instead of `node20`
- Node.js 20 reaches EOL in April 2026 and GitHub Actions is [deprecating node20 runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
- GitHub is skipping `node22` and moving directly to `node24`

Closes #87

## Test plan
- [ ] Test with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env var in a workflow using this action
- [ ] Reference the branch directly in a test workflow: `uses: javiercm1410/actions@chore/update-node24`
- [ ] Verify werf install, build, converge, cleanup, dismiss, and run actions all work under Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)